### PR TITLE
Pass state settings to base class from constructor

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Core.Extensions/BotState.cs
+++ b/libraries/Microsoft.Bot.Builder.Core.Extensions/BotState.cs
@@ -168,7 +168,8 @@ namespace Microsoft.Bot.Builder.Core.Extensions
         public UserState(IStorage storage, StateSettings settings = null) :
             base(storage,
                 PropertyName,
-                (context) => $"user/{context.Activity.ChannelId}/{context.Activity.From.Id}")
+                (context) => $"user/{context.Activity.ChannelId}/{context.Activity.From.Id}",
+                settings)
         {
         }
 


### PR DESCRIPTION
StateSettings state in the constructor is currently (incorrectly) unused. It is intended to be passed on to the base class.